### PR TITLE
feat: allow LAN access by binding to 0.0.0.0

### DIFF
--- a/bin/serve.py
+++ b/bin/serve.py
@@ -351,7 +351,7 @@ def run(port, web_dir, oroio_dir, dk_path):
         *args, oroio_dir=oroio_dir, dk_path=dk_path, **kwargs
     )
     
-    with http.server.HTTPServer(('127.0.0.1', port), handler) as httpd:
+    with http.server.HTTPServer(('0.0.0.0', port), handler) as httpd:
         httpd.serve_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 背景
对于在局域网服务器上部署 oroio 的场景，当前绑定 `127.0.0.1` 导致其他设备无法访问 Web 界面。

## 改动
将 `serve.py` 中的监听地址从 `127.0.0.1` 改为 `0.0.0.0`，允许局域网内其他设备访问。

## 使用场景
- 在家庭/办公室服务器上部署 oroio
- 通过手机或其他电脑管理 API keys