### PR TITLE
fix: use ThreadingHTTPServer to prevent blocking on concurrent connections

### DIFF
--- a/bin/serve.py
+++ b/bin/serve.py
@@ -9,6 +9,7 @@ import platform
 import secrets
 import subprocess
 import sys
+import threading
 import urllib.request
 import urllib.error
 from urllib.parse import unquote
@@ -710,7 +711,7 @@ def run(port, web_dir, oroio_dir, dk_path, pin_hash=None):
         *args, oroio_dir=oroio_dir, dk_path=dk_path, **kwargs
     )
     
-    with http.server.HTTPServer(('0.0.0.0', port), handler) as httpd:
+    with http.server.ThreadingHTTPServer(('0.0.0.0', port), handler) as httpd:
         httpd.serve_forever()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

When using VS Code Remote (SSH/WSL/Container) or other tools that establish multiple HTTP connections to the `dk serve` web dashboard, the single-threaded `HTTPServer` can become blocked, making the dashboard inaccessible.

This happens because `http.server.HTTPServer` processes requests sequentially - if one connection is slow or kept open, all other connections are blocked.

## Solution

Replace `HTTPServer` with `ThreadingHTTPServer`, which handles each request in a separate thread. This prevents blocking while maintaining the same API.

## Changes

- Added `import threading`
- Changed `http.server.HTTPServer` to `http.server.ThreadingHTTPServer`

## Testing

Tested with VS Code Remote SSH where multiple connections are established. The dashboard remains responsive even with concurrent connections.